### PR TITLE
Add the possibility to use a dedicated Kerberos cache file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ using the keytab
 
 `Kerberos keytab` - The path to the keytab file used to authenticate the principal
 
+`Use a dedicated cache file` - Useful when multiple Kerberos principals are in use.
+
+`Kerberos cache filename` - Specify manually the cache filename.
+
+`Destroy Kerberos ticket` - Perform a kdestroy before exiting the plugin, not recommended.
+
 Requirements
 ------------
 The plugin requires Rundeck version 2.4.0 or higher.

--- a/ssh-krb-node-executor-plugin/contents/scp-krb-executor.sh
+++ b/ssh-krb-node-executor-plugin/contents/scp-krb-executor.sh
@@ -13,34 +13,38 @@ shift
 SRC_FILE=$1
 shift
 DEST_FILE=$1
-KERB_KEYTAB=$RD_CONFIG_KERBEROS_KEYTAB
 
-if [ ! -f "$KERB_KEYTAB" ]; then
-  echo "Keytab $KERB_KEYTAB not found" >&2
+if [ ! -f "$RD_CONFIG_KERBEROS_KEYTAB" ]; then
+  echo "Keytab $RD_CONFIG_KERBEROS_KEYTAB not found" >&2
   exit 2
 fi
 
 # random delay (0..0.5s) to make it work with parallel exec
 sleep "$(bc <<< "scale=2; $(printf '0.%02d' $(( RANDOM % 100))) / 2")"
 
-# status 1 if the credentials cache cannot be read or is expired, and with status 0 otherwise
-klist -s
-if [ $? -ne 0 ]; then
-  kinit -kt "$KERB_KEYTAB" "$RD_CONFIG_KERBEROS_USER"
+# override the default kerberos cache file if required
+if [ "$RD_CONFIG_USE_KERBEROS_CUSTOM_CACHE_FILE" = 'true' ]; then
+  if [ -n "$RD_CONFIG_KERBEROS_CUSTOM_CACHE_FILENAME" ]; then
+    export KRB5CCNAME="$RD_CONFIG_KERBEROS_CUSTOM_CACHE_FILENAME"
+  else
+    export KRB5CCNAME="/tmp/krb5cc_$(id -ru)_rundeck_$RD_CONFIG_KERBEROS_USER"
+  fi
+fi
 
-  # verify ticket has been successfuly created
-  klist -s
-  if [ $? -ne 0 ]; then
-    echo "Kinit failure when calling kinit -kt $KERB_KEYTAB $RD_CONFIG_KERBEROS_USER" >&2
+# recreate the cache if it's expired or not present
+if ! klist -s; then
+  kinit -kt "$RD_CONFIG_KERBEROS_KEYTAB" "$RD_CONFIG_KERBEROS_USER"
+  if ! klist -s; then
+    echo "Kinit failure when calling kinit -kt $RD_CONFIG_KERBEROS_KEYTAB $RD_CONFIG_KERBEROS_USER" >&2
     exit 2
   fi
 fi
 
 SSHOPTS=" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=quiet -o GSSAPIDelegateCredentials=yes"
-RUNSSH="scp $SSHOPTS $SRC_FILE $USER@$HOST:$DEST_FILE"
+RUNSSH='scp $SSHOPTS "$SRC_FILE" $USER@$HOST:"${DEST_FILE// /\\ }"'
 
 #finally, execute scp but don't print to STDOUT
-$RUNSSH 1>&2 || exit $? # exit if not successful
+eval $RUNSSH 1>&2 || exit $? # exit if not successful
 echo "$DEST_FILE" # echo remote filepath
 
 if [[ ${RD_CONFIG_DO_KDESTROY} == 'true' ]]; then

--- a/ssh-krb-node-executor-plugin/contents/ssh-krb-executor.sh
+++ b/ssh-krb-node-executor-plugin/contents/ssh-krb-executor.sh
@@ -11,25 +11,29 @@ shift
 HOST=$1
 shift
 CMD=$*
-KERB_KEYTAB=$RD_CONFIG_KERBEROS_KEYTAB
 
-if [ ! -f "$KERB_KEYTAB" ]; then
-  echo "Keytab $KERB_KEYTAB not found" >&2
+if [ ! -f "$RD_CONFIG_KERBEROS_KEYTAB" ]; then
+  echo "Keytab $RD_CONFIG_KERBEROS_KEYTAB not found" >&2
   exit 2
 fi
 
 # random delay (0..0.5s) to make it work with parallel exec
 sleep "$(bc <<< "scale=2; $(printf '0.%02d' $(( RANDOM % 100))) / 2")"
 
-# status 1 if the credentials cache cannot be read or is expired, and with status 0 otherwise
-klist -s
-if [ $? -ne 0 ]; then
-  kinit -kt "$KERB_KEYTAB" "$RD_CONFIG_KERBEROS_USER"
+# override the default kerberos cache file if required
+if [ "$RD_CONFIG_USE_KERBEROS_CUSTOM_CACHE_FILE" = 'true' ]; then
+  if [ -n "$RD_CONFIG_KERBEROS_CUSTOM_CACHE_FILENAME" ]; then
+    export KRB5CCNAME="$RD_CONFIG_KERBEROS_CUSTOM_CACHE_FILENAME"
+  else
+    export KRB5CCNAME="/tmp/krb5cc_$(id -ru)_rundeck_$RD_CONFIG_KERBEROS_USER"
+  fi
+fi
 
-  # verify ticket has been successfuly created
-  klist -s
-  if [ $? -ne 0 ]; then
-    echo "Kinit failure when calling kinit -kt $KERB_KEYTAB $RD_CONFIG_KERBEROS_USER" >&2
+# recreate the cache if it's expired or not present
+if ! klist -s; then
+  kinit -kt "$RD_CONFIG_KERBEROS_KEYTAB" "$RD_CONFIG_KERBEROS_USER"
+  if ! klist -s; then
+    echo "Kinit failure when calling kinit -kt $RD_CONFIG_KERBEROS_KEYTAB $RD_CONFIG_KERBEROS_USER" >&2
     exit 2
   fi
 fi

--- a/ssh-krb-node-executor-plugin/plugin.yaml
+++ b/ssh-krb-node-executor-plugin/plugin.yaml
@@ -23,6 +23,16 @@ providers:
           type: String
           required: true
           description: "The path and filename to the Kerberos key table used to authenticate the user (e.g. /tmp/user.ktab)"
+        - name: use_kerberos_custom_cache_file
+          title: Use a dedicated cache file
+          type: Boolean
+          required: false
+          description: "If selected, the Kerberos credentials cache file will be stored in a dedicated location. Recommended when multiple Kerberos principals are in use in this Rundeck instance because initiating another principal will override the current principal present in the default cache file, if any."
+        - name: kerberos_custom_cache_filename
+          title: Kerberos cache filename
+          type: String
+          required: false
+          description: "Define a custom location for the dedicated Kerberos credentials cache file, otherwise it will use the pattern /tmp/krb5cc_<UID>_rundeck_<KERBEROS_USER>"
         - name: do_kdestroy
           title: Destroy kerberos ticket
           type: Boolean
@@ -48,6 +58,16 @@ providers:
           type: String
           required: true
           description: "The path and filename to the Kerberos key table used to authenticate the user (e.g. /tmp/user.ktab)"
+        - name: use_kerberos_custom_cache_file
+          title: Use a dedicated cache file
+          type: Boolean
+          required: false
+          description: "If selected, the Kerberos credentials cache file will be stored in a dedicated location. Recommended when multiple Kerberos principals are in use in this Rundeck instance because initiating another principal will override the current principal present in the default cache file, if any."
+        - name: kerberos_custom_cache_filename
+          title: Kerberos cache filename
+          type: String
+          required: false
+          description: "Define a custom location for the dedicated Kerberos credentials cache file, otherwise it will use the pattern /tmp/krb5cc_<UID>_rundeck_<KERBEROS_USER>"
         - name: do_kdestroy
           title: Destroy kerberos ticket
           type: Boolean


### PR DESCRIPTION
Add the possibility to override the default credential cache file thanks to the `KRB5CCNAME` environment variable.
That means it can change the default location pattern (eg. `/tmp/krb5cc_<RUNDECK_UID>`) to a more precise one (`/tmp/krb5cc_<RUNDECK_UID>_rundeck_<KRB_USER>`), or even an user defined location.

This customization is required when you've multiple projects in your Rundeck server that didn't use the same Kerberos principal, because only the last `kinit`'ed principal will be working at a given time.

