### PR TITLE
make do_kdestroy not required

### DIFF
--- a/ssh-krb-node-executor-plugin/plugin.yaml
+++ b/ssh-krb-node-executor-plugin/plugin.yaml
@@ -72,5 +72,5 @@ providers:
         - name: do_kdestroy
           title: Destroy kerberos ticket
           type: Boolean
-          required: true
+          required: false
           description: "If selected, the kerberos ticket will be destroyed at the end of the execution"

--- a/ssh-krb-node-executor-plugin/plugin.yaml
+++ b/ssh-krb-node-executor-plugin/plugin.yaml
@@ -37,7 +37,7 @@ providers:
         - name: do_kdestroy
           title: Destroy kerberos ticket
           type: Boolean
-          required: true
+          required: false
           description: "If selected, the kerberos ticket will be destroyed at the end of the execution"
 
     - name: scp-krb


### PR DESCRIPTION
When upgrading to rundeck v4, the field for do_kdestroy is a checkbox. If it is not checked then errors are thrown:

`
NodeExecutor: configuration was not valid for plugin 'ssh-krb': do_kdestroy: required
`

I think making a boolean required must be for things like terms and conditions