### PR TITLE
use temp KRB5CCACHE if we'll delete them later

### DIFF
--- a/ssh-krb-node-executor-plugin/contents/scp-krb-executor.sh
+++ b/ssh-krb-node-executor-plugin/contents/scp-krb-executor.sh
@@ -26,6 +26,8 @@ sleep "$(bc <<< "scale=2; $(printf '0.%02d' $(( RANDOM % 100))) / 2")"
 if [ "$RD_CONFIG_USE_KERBEROS_CUSTOM_CACHE_FILE" = 'true' ]; then
   if [ -n "$RD_CONFIG_KERBEROS_CUSTOM_CACHE_FILENAME" ]; then
     export KRB5CCNAME="$RD_CONFIG_KERBEROS_CUSTOM_CACHE_FILENAME"
+  elif [[ ${RD_CONFIG_DO_KDESTROY} == 'true' ]]; then
+    export KRB5CCNAME=$(mktemp "/tmp/krb5cc_XXXXXX_rundeck_$RD_CONFIG_KERBEROS_USER"
   else
     export KRB5CCNAME="/tmp/krb5cc_$(id -ru)_rundeck_$RD_CONFIG_KERBEROS_USER"
   fi

--- a/ssh-krb-node-executor-plugin/contents/ssh-krb-executor.sh
+++ b/ssh-krb-node-executor-plugin/contents/ssh-krb-executor.sh
@@ -24,6 +24,8 @@ sleep "$(bc <<< "scale=2; $(printf '0.%02d' $(( RANDOM % 100))) / 2")"
 if [ "$RD_CONFIG_USE_KERBEROS_CUSTOM_CACHE_FILE" = 'true' ]; then
   if [ -n "$RD_CONFIG_KERBEROS_CUSTOM_CACHE_FILENAME" ]; then
     export KRB5CCNAME="$RD_CONFIG_KERBEROS_CUSTOM_CACHE_FILENAME"
+  elif [[ ${RD_CONFIG_DO_KDESTROY} == 'true' ]]; then
+    export KRB5CCNAME=$(mktemp "/tmp/krb5cc_XXXXXX_rundeck_$RD_CONFIG_KERBEROS_USER"
   else
     export KRB5CCNAME="/tmp/krb5cc_$(id -ru)_rundeck_$RD_CONFIG_KERBEROS_USER"
   fi


### PR DESCRIPTION
to avoid any interference between parallel jobs that are set to `kdestroy` at end, use temporary filenames for our Kerberos5 credential caches.